### PR TITLE
Fix django Shell

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pathlib2==2.3.2
 pathtools==0.1.2
 pdfrw==0.4
 pexpect==4.6.0
-pickleshare==0.7.4
+pickleshare==0.7.5
 Pillow
 port-for==0.3.1
 prompt-toolkit==3.0.30


### PR DESCRIPTION
Recent upgrade (python3.10) broke Django shell.

```
swordphish@swordphish:~$ ./manage.py shell
Traceback (most recent call last):
  File "/opt/swordphish/./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.10/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.10/site-packages/django/core/management/__init__.py", line 440, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 402, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 448, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.10/site-packages/django/core/management/commands/shell.py", line 136, in handle
    return getattr(self, shell)(options)
  File "/usr/local/lib/python3.10/site-packages/django/core/management/commands/shell.py", line 48, in ipython
    from IPython import start_ipython
  File "/usr/local/lib/python3.10/site-packages/IPython/__init__.py", line 53, in <module>
    from .terminal.embed import embed
  File "/usr/local/lib/python3.10/site-packages/IPython/terminal/embed.py", line 15, in <module>
    from IPython.core.interactiveshell import DummyMod, InteractiveShell
  File "/usr/local/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 40, in <module>
    from pickleshare import PickleShareDB
  File "/usr/local/lib/python3.10/site-packages/pickleshare.py", line 66, in <module>
    class PickleShareDB(collections.MutableMapping):
AttributeError: module 'collections' has no attribute 'MutableMapping'
```