### PR TITLE
hide tracking image

### DIFF
--- a/Main/models.py
+++ b/Main/models.py
@@ -400,8 +400,10 @@ class Campaign(models.Model):
 
         if self.enable_mail_tracker:
             if not soup.findAll("img", attrs={"src": "FIXMEMAILTRACKER"}):
-                img = soup.new_tag("img", src="FIXMEMAILTRACKER")
-                soup.body.append(img)
+                div = soup.new_tag('div', style='display: none')
+                img = soup.new_tag("img", src="FIXMEMAILTRACKER", width=1, height=1)
+                div.append(img)
+                soup.body.append(div)
 
         return {"text": str(soup), "imgs": imgs}
 


### PR DESCRIPTION
Mail tracking image appears as a white dot when dark mode is enabled in Outlook/Windows.
Knowing that Outlook does not allow hiding `img` tags, adding it to a hidden `div` solves the issue.